### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const RateLimit = require('express-rate-limit');
 const db = require('./database'); // Подключение к базе данных
 const path = require('path');
 const app = express();
@@ -11,6 +12,12 @@ app.set('views', path.join(__dirname, "views"));
 
 app.use(express.static(path.join(__dirname, 'public')));
 
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
 // Основной маршрут для отображения главной страницы dashboard
 app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, 'views', 'dashboard.html'));
@@ -18,7 +25,7 @@ app.get('/', (req, res) => {
 
 
 // Маршрут для отображения логов
-app.get('/logs', (req, res) => {
+app.get('/logs', limiter, (req, res) => {
     db.all('SELECT * FROM logs ORDER BY timestamp DESC', [], (err, rows) => {
         if (err) {
             res.status(500).send('Ошибка при получении данных из базы');

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "@discordjs/rest": "^2.4.0",
     "axios": "^1.7.7",
     "discord-api-types": "^0.37.100",
-    "discord.js": "^14.16.2"
+    "discord.js": "^14.16.2",
+    "express-rate-limit": "^7.4.1"
   },
   "name": "idleclansdiscordbot",
   "version": "1.0.0",


### PR DESCRIPTION
Fixes [https://github.com/Nike73/IdleClansDiscordBotOnJS/security/code-scanning/2](https://github.com/Nike73/IdleClansDiscordBotOnJS/security/code-scanning/2)

To fix the problem, we will introduce a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests to the `/logs` endpoint to a reasonable number within a specified time window. This will help prevent potential DoS attacks by limiting the rate at which requests can be made to the server.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `dashboard.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to the `/logs` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
